### PR TITLE
WIP: Read Custom Hotel Port

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -68,6 +68,7 @@ const createWindow = () => {
     webPreferences: {
       backgroundThrottling: false,
       preload: path.join(__dirname, 'preload.js'),
+      nodeIntegration: true,
     },
   });
   const startUrl = process.env.ELECTRON_START_URL || url.format({
@@ -75,6 +76,9 @@ const createWindow = () => {
     protocol: 'file:',
     slashes: true,
   });
+
+  // Send hotelPort to renderer process before loading the `startUrl`
+  window.webContents.send('hotelPort', { msg: window.hotelPort });
   window.loadURL(startUrl);
 
   window.on('blur', () => {

--- a/public/electron.js
+++ b/public/electron.js
@@ -1,59 +1,60 @@
 const electron = require('electron');
-const { app, BrowserWindow, ipcMain, Tray } = electron;
+const { app, BrowserWindow, ipcMain, Tray } = electron; // eslint-disable-line no-unused-vars
 const path = require('path');
 const url = require('url');
 
-const assetsDirectory = path.join(__dirname, './assets')
+const assetsDirectory = path.join(__dirname, './assets');
 
-let tray = undefined;
-let window = undefined;
+let tray;
+let window;
 // workaround for Windows, where blur event occured when clicking on a tray icon
 let blurredRecently = false;
 
 if (process.platform === 'darwin') {
-  app.dock.hide()
+  app.dock.hide();
 }
 
 app.on('ready', () => {
-  createTray()
-  createWindow()
-})
+  createTray();
+  createWindow();
+});
 
 app.on('window-all-closed', () => {
-  app.quit()
-})
+  app.quit();
+});
 
 const createTray = () => {
   if (process.platform === 'darwin') {
-    tray = new Tray(path.join(assetsDirectory, 'hotelTemplate.png'))
+    tray = new Tray(path.join(assetsDirectory, 'hotelTemplate.png'));
   } else {
-    tray = new Tray(path.join(assetsDirectory, 'hotelTemplate_white.png'))
+    tray = new Tray(path.join(assetsDirectory, 'hotelTemplate_white.png'));
   }
-  tray.on('right-click', toggleWindow)
-  tray.on('click', function (event) {
-    toggleWindow()
+  tray.on('right-click', toggleWindow);
+  tray.on('click', function(event) {
+    toggleWindow();
 
     if (window.isVisible() && process.defaultApp && event.metaKey) {
-      window.openDevTools({ mode: 'detach' })
+      window.openDevTools({ mode: 'detach' });
     }
-  })
-}
+  });
+};
 
 const getWindowPosition = () => {
-  const windowBounds = window.getBounds()
-  const trayBounds = tray.getBounds()
+  const windowBounds = window.getBounds();
+  const trayBounds = tray.getBounds();
+  // eslint-disable-next-line no-unused-vars
   const { width, height } = electron.screen.getPrimaryDisplay().workAreaSize;
 
-  const x = Math.round(trayBounds.x + (trayBounds.width / 2) - (windowBounds.width / 2))
+  const x = Math.round(trayBounds.x + (trayBounds.width / 2) - (windowBounds.width / 2));
 
-  let y = Math.round(trayBounds.y + trayBounds.height + 4)
+  let y = Math.round(trayBounds.y + trayBounds.height + 4);
 
   if (height < y) {
-    y = Math.round(trayBounds.y - windowBounds.height - 4)
+    y = Math.round(trayBounds.y - windowBounds.height - 4);
   }
 
-  return { x: x, y: y }
-}
+  return { x: x, y: y };
+};
 
 const createWindow = () => {
   window = new BrowserWindow({
@@ -67,12 +68,12 @@ const createWindow = () => {
     webPreferences: {
       backgroundThrottling: false,
       preload: path.join(__dirname, 'preload.js'),
-    }
-  })
+    },
+  });
   const startUrl = process.env.ELECTRON_START_URL || url.format({
     pathname: path.join(__dirname, './index.html'),
     protocol: 'file:',
-    slashes: true
+    slashes: true,
   });
   window.loadURL(startUrl);
 
@@ -80,22 +81,22 @@ const createWindow = () => {
     blurredRecently = true;
     setTimeout(() => blurredRecently = false, 100);
     if (!window.webContents.isDevToolsOpened()) {
-      window.hide()
+      window.hide();
     }
-  })
-}
+  });
+};
 
 const toggleWindow = () => {
   if (window.isVisible() || blurredRecently) {
-    window.hide()
+    window.hide();
   } else {
-    showWindow()
+    showWindow();
   }
-}
+};
 
 const showWindow = () => {
-  const position = getWindowPosition()
-  window.setPosition(position.x, position.y, false)
-  window.show()
-  window.focus()
-}
+  const position = getWindowPosition();
+  window.setPosition(position.x, position.y, false);
+  window.show();
+  window.focus();
+};

--- a/public/electron.js
+++ b/public/electron.js
@@ -76,9 +76,6 @@ const createWindow = () => {
     protocol: 'file:',
     slashes: true,
   });
-
-  // Send hotelPort to renderer process before loading the `startUrl`
-  window.webContents.send('hotelPort', { msg: window.hotelPort });
   window.loadURL(startUrl);
 
   window.on('blur', () => {

--- a/public/preload.js
+++ b/public/preload.js
@@ -2,12 +2,13 @@ const fs = require('fs');
 const path = require('path');
 const homedir = require('os').homedir();
 // eslint-disable-next-line no-unused-vars
-const { shell, Tray } = require('electron');
+const { shell, Tray, ipcRenderer } = require('electron');
 
 // Read Hotel config and store port number
 const hotelConfigPath = path.join(homedir, '.hotel', 'conf.json');
 const hotelPort = JSON.parse(fs.readFileSync(hotelConfigPath)).port;
 
-// Attach electron shell and hotel port to window object
+// Attach electron shell, ipcRenderer, and hotelPort to window object
 window.shell = shell;
 window.hotelPort = hotelPort ? hotelPort.toString() : '2000';
+window.ipcRenderer = ipcRenderer;

--- a/public/preload.js
+++ b/public/preload.js
@@ -1,2 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+const homedir = require('os').homedir();
 const { shell, Tray } = require('electron');
+
+// Read Hotel config and store port number
+const hotelConfigPath = path.join(homedir, '.hotel', 'conf.json');
+const hotelPort = JSON.parse(fs.readFileSync(hotelConfigPath)).port;
+
+// Attach electron shell and hotel port to window object
 window.shell = shell;
+window.hotelPort = hotelPort ? hotelPort.toString() : '2000';

--- a/public/preload.js
+++ b/public/preload.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const homedir = require('os').homedir();
+// eslint-disable-next-line no-unused-vars
 const { shell, Tray } = require('electron');
 
 // Read Hotel config and store port number

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,4 @@
 import isElectron from 'is-electron';
-import fs from 'fs';
-import { ipcRenderer } from 'electron';
-
-console.log(fs);
-
-ipcRenderer.once('hotelPort', (msg) => {
-  // window.hotelPort =
-  console.log(msg);
-});
 
 export default class Utils {
   static isElectron = () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,13 @@
 import isElectron from 'is-electron';
+import fs from 'fs';
+import { ipcRenderer } from 'electron';
+
+console.log(fs);
+
+ipcRenderer.once('hotelPort', (msg) => {
+  // window.hotelPort =
+  console.log(msg);
+});
 
 export default class Utils {
   static isElectron = () => {


### PR DESCRIPTION
This PR includes changes to load a custom port set in the user's Hotel config at `~/.hotel.js/conf.json` (`%homepath%\.hotel.js\conf.json` on Windows).

The hotel port is set in `public/preload.js` and added to the `window`.

This PR also includes `ipcRenderer` to try to request the hotelPort from within the `BrowserWindow` object. However, it's possible `ipcRenderer` is unnecessary if the `hotelPort` value is added to the `window` object directly.

Currently neither `window.hotelPort` nor `window.ipcRenderer` are accessible from the client.

----

*Previous discussions on issue #3*